### PR TITLE
fix: area not beeing interactable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# egui-modal-spinner changelog
+
+## 2024-12-02
+
+### 🐛 Bug Fixes
+- Fixed issue with widgets being interactable behind the modal background [#7](https://github.com/fluxxcode/egui-modal-spinner/pull/7)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,7 +261,7 @@ impl ModalSpinner {
 
         let re = egui::Area::new(id)
             .movable(false)
-            .interactable(false)
+            .interactable(true)
             .fixed_pos(screen_rect.left_top())
             .fade_in(self.fade_in)
             .show(ctx, |ui| {
@@ -279,6 +279,8 @@ impl ModalSpinner {
 
                 ui.painter()
                     .rect_filled(screen_rect, egui::Rounding::ZERO, fill_color);
+
+                ui.allocate_response(screen_rect.size(), egui::Sense::click());
 
                 let child_ui = egui::UiBuilder::new()
                     .max_rect(screen_rect)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,7 @@ impl ModalSpinner {
 
         let re = egui::Area::new(id)
             .movable(false)
+            .interactable(false)
             .fixed_pos(screen_rect.left_top())
             .fade_in(self.fade_in)
             .show(ctx, |ui| {


### PR DESCRIPTION
Fixed the modal area being non-interactive, allowing buttons and scrolls to be hovered behind the modal.