### PR TITLE
Update egui to v0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,11 @@
 members = ["examples/*"]
 
 [workspace.dependencies]
-eframe = { version = "0.29.1", default-features = false, features = [
+eframe = { version = "0.30.0", default-features = false, features = [
     "glow",
     "persistence",
+    "x11",
+    "wayland"
 ] }
 
 [package]
@@ -19,7 +21,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-egui = "0.29.1"
+egui = "0.30.0"
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
Update egui to v0.30. I had to add the `x11`/`wayland` features, because winit would produce the following error message without them
```
error: The platform you're compiling for is not supported by winit
```